### PR TITLE
Fix typo in FrameManager comment

### DIFF
--- a/src/FrameManager.cpp
+++ b/src/FrameManager.cpp
@@ -96,7 +96,7 @@ bool FrameManager::beginFrame(vk::SwapchainKHR swapchain, uint32_t& outImageInde
         m_device.waitForFences(m_imagesInFlight[outImageIndex], VK_TRUE, UINT64_MAX);
     }
 
-    // Associate the current frame's fence with the aquired swapchain image
+    // Associate the current frame's fence with the acquired swapchain image
     m_imagesInFlight[outImageIndex] = m_frames[m_currentFrame].inFlightFence;
 
     m_device.resetFences(m_frames[m_currentFrame].inFlightFence);


### PR DESCRIPTION
## Summary
- fix comment typo in `FrameManager.cpp`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68517fd0ecd48330986b717f2483cdf9