### PR TITLE
Fix missing optional include

### DIFF
--- a/src/VulkanContext.hpp
+++ b/src/VulkanContext.hpp
@@ -8,6 +8,7 @@
 #include <vulkan/vulkan.hpp>
 #include <GLFW/glfw3.h>
 #include <memory>
+#include <optional>
 
 namespace reactor {
 


### PR DESCRIPTION
## Summary
- include `<optional>` in `VulkanContext.hpp`

## Testing
- `cmake ..` *(fails: CMake 3.31 or higher is required)*

------
https://chatgpt.com/codex/tasks/task_e_6851738980508330af7e19f8d7ce3397