### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,15 @@ jobs:
         with:
           submodules: true
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libvulkan-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libvulkan-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            xorg-dev \
+            libglu1-mesa-dev \
+            pkg-config
       - name: Bootstrap vcpkg
         run: ./vcpkg/bootstrap-vcpkg.sh
       - name: Configure CMake


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build the project using CMake and vcpkg

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_6851a8db54f88330abe02b159ab1e069