### PR TITLE
Render cube geometry

### DIFF
--- a/shaders/triangle.vert
+++ b/shaders/triangle.vert
@@ -8,19 +8,67 @@ layout(set = 0, binding = 0) uniform UBO {
 layout(location = 0) out vec3 vColor;
 
 void main() {
-    // Hardcoded triangle in normalized device coordinates (NDC)
-    vec3 positions[3] = vec3[](
-        vec3(0.0, -0.5, 0.0),   // bottom
-        vec3(0.5, 0.5, 0.0),    // right
-        vec3(-0.5, 0.5, 0.0)    // left
+    // Hardcoded cube made of 12 triangles (36 vertices)
+    vec3 positions[36] = vec3[](
+        // Front face
+        vec3(-0.5, -0.5,  0.5),
+        vec3( 0.5, -0.5,  0.5),
+        vec3( 0.5,  0.5,  0.5),
+        vec3(-0.5, -0.5,  0.5),
+        vec3( 0.5,  0.5,  0.5),
+        vec3(-0.5,  0.5,  0.5),
+
+        // Back face
+        vec3(-0.5, -0.5, -0.5),
+        vec3( 0.5,  0.5, -0.5),
+        vec3( 0.5, -0.5, -0.5),
+        vec3(-0.5, -0.5, -0.5),
+        vec3(-0.5,  0.5, -0.5),
+        vec3( 0.5,  0.5, -0.5),
+
+        // Left face
+        vec3(-0.5, -0.5, -0.5),
+        vec3(-0.5, -0.5,  0.5),
+        vec3(-0.5,  0.5,  0.5),
+        vec3(-0.5, -0.5, -0.5),
+        vec3(-0.5,  0.5,  0.5),
+        vec3(-0.5,  0.5, -0.5),
+
+        // Right face
+        vec3( 0.5, -0.5, -0.5),
+        vec3( 0.5,  0.5,  0.5),
+        vec3( 0.5, -0.5,  0.5),
+        vec3( 0.5, -0.5, -0.5),
+        vec3( 0.5,  0.5, -0.5),
+        vec3( 0.5,  0.5,  0.5),
+
+        // Top face
+        vec3(-0.5,  0.5, -0.5),
+        vec3(-0.5,  0.5,  0.5),
+        vec3( 0.5,  0.5,  0.5),
+        vec3(-0.5,  0.5, -0.5),
+        vec3( 0.5,  0.5,  0.5),
+        vec3( 0.5,  0.5, -0.5),
+
+        // Bottom face
+        vec3(-0.5, -0.5, -0.5),
+        vec3( 0.5, -0.5,  0.5),
+        vec3(-0.5, -0.5,  0.5),
+        vec3(-0.5, -0.5, -0.5),
+        vec3( 0.5, -0.5, -0.5),
+        vec3( 0.5, -0.5,  0.5)
     );
 
-    vec3 colors[3] = vec3[](
-        vec3(1.0, 0.0, 0.0), // Red
-        vec3(0.0, 1.0, 0.0), // Green
-        vec3(0.0, 0.0, 1.0)  // Blue
+    vec3 colors[6] = vec3[](
+        vec3(1.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        vec3(0.0, 0.0, 1.0),
+        vec3(1.0, 1.0, 0.0),
+        vec3(1.0, 0.0, 1.0),
+        vec3(0.0, 1.0, 1.0)
     );
 
+    int face = gl_VertexIndex / 6; // Each face has 6 vertices
     gl_Position = projection * view * vec4(positions[gl_VertexIndex], 1.0);
-    vColor = colors[gl_VertexIndex];
+    vColor = colors[face];
 }

--- a/src/vulkan/VulkanRenderer.cpp
+++ b/src/vulkan/VulkanRenderer.cpp
@@ -113,7 +113,7 @@ void VulkanRenderer::bindDescriptorSets(vk::CommandBuffer cmd) {
 
 void VulkanRenderer::drawGeometry(vk::CommandBuffer cmd) {
     cmd.bindPipeline(vk::PipelineBindPoint::eGraphics, m_pipeline->get());
-    cmd.draw(3, 1, 0, 0);
+    cmd.draw(36, 1, 0, 0);
 }
 
 void VulkanRenderer::renderUI(const vk::CommandBuffer cmd) const {


### PR DESCRIPTION
## Summary
- update vertex shader to emit a cube instead of a simple triangle
- increase geometry draw call to 36 vertices

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_686f132a19d88330bef391c5fefd8d90