### PR TITLE
Render post-processed scene in ImGui

### DIFF
--- a/src/vulkan/VulkanRenderer.hpp
+++ b/src/vulkan/VulkanRenderer.hpp
@@ -59,6 +59,8 @@ private:
 
     std::vector<std::unique_ptr<Image>> m_resolveImages;
     std::vector<vk::ImageView> m_resolveViews;
+    std::vector<std::unique_ptr<Image>> m_sceneViewImages;
+    std::vector<vk::ImageView> m_sceneViewViews;
     std::vector<vk::DescriptorSet> m_sceneViewImageDescriptorSets;
 
     void createCoreVulkanObjects();
@@ -67,6 +69,7 @@ private:
     void setupUI();
     void createMSAAImage();
     void createResolveImages();
+    void createSceneViewImages();
     void createSampler();
     void createDescriptorSets();
 

--- a/src/vulkan/VulkanUtils.hpp
+++ b/src/vulkan/VulkanUtils.hpp
@@ -27,6 +27,26 @@ inline void resolveMSAAImageTo(vk::CommandBuffer cmd, vk::Image msaaImage, vk::I
                      vk::ImageLayout::eTransferDstOptimal, 1, &resolveRegion);
 }
 
+inline void copyImage(vk::CommandBuffer cmd,
+                      vk::Image srcImage,
+                      vk::ImageLayout srcLayout,
+                      vk::Image dstImage,
+                      vk::ImageLayout dstLayout,
+                      uint32_t width,
+                      uint32_t height) {
+    vk::ImageCopy copyRegion{};
+    copyRegion.srcSubresource.aspectMask     = vk::ImageAspectFlagBits::eColor;
+    copyRegion.srcSubresource.mipLevel       = 0;
+    copyRegion.srcSubresource.baseArrayLayer = 0;
+    copyRegion.srcSubresource.layerCount     = 1;
+    copyRegion.srcOffset                     = vk::Offset3D{0, 0, 0};
+    copyRegion.dstSubresource                = copyRegion.srcSubresource;
+    copyRegion.dstOffset                     = vk::Offset3D{0, 0, 0};
+    copyRegion.extent                        = vk::Extent3D{width, height, 1};
+
+    cmd.copyImage(srcImage, srcLayout, dstImage, dstLayout, 1, &copyRegion);
+}
+
 inline void setupViewportAndScissor(vk::CommandBuffer cmd, vk::Extent2D extent) {
     vk::Viewport viewport{};
     viewport.x        = 0.0f;


### PR DESCRIPTION
## Summary
- allocate per-frame images for showing the post processed scene
- copy the composited swapchain image to these scene-view images each frame
- expose the post processed image to ImGui via descriptor sets
- add helper for image copies

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_686f13f162248330910475f8e7f53802