### PR TITLE
Render cube geometry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(Reactor src/core/main.cpp
         src/vulkan/ImageStateTracker.cpp
         src/vulkan/ImageStateTracker.h
         src/core/Uniforms.hpp
+        src/core/Vertex.hpp
         src/vulkan/UniformManager.cpp
         src/vulkan/UniformManager.hpp
         src/vulkan/ShaderModule.cpp

--- a/shaders/triangle.vert
+++ b/shaders/triangle.vert
@@ -5,22 +5,11 @@ layout(set = 0, binding = 0) uniform UBO {
     mat4 projection;
 };
 
+layout(location = 0) in vec3 inPos;
+layout(location = 1) in vec3 inColor;
 layout(location = 0) out vec3 vColor;
 
 void main() {
-    // Hardcoded triangle in normalized device coordinates (NDC)
-    vec3 positions[3] = vec3[](
-        vec3(0.0, -0.5, 0.0),   // bottom
-        vec3(0.5, 0.5, 0.0),    // right
-        vec3(-0.5, 0.5, 0.0)    // left
-    );
-
-    vec3 colors[3] = vec3[](
-        vec3(1.0, 0.0, 0.0), // Red
-        vec3(0.0, 1.0, 0.0), // Green
-        vec3(0.0, 0.0, 1.0)  // Blue
-    );
-
-    gl_Position = projection * view * vec4(positions[gl_VertexIndex], 1.0);
-    vColor = colors[gl_VertexIndex];
+    gl_Position = projection * view * vec4(inPos, 1.0);
+    vColor = inColor;
 }

--- a/src/core/Vertex.hpp
+++ b/src/core/Vertex.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <vulkan/vulkan.hpp>
+#include <array>
+
+struct Vertex {
+    glm::vec3 pos;
+    glm::vec3 color;
+
+    static vk::VertexInputBindingDescription bindingDescription() {
+        vk::VertexInputBindingDescription desc{};
+        desc.binding = 0;
+        desc.stride = sizeof(Vertex);
+        desc.inputRate = vk::VertexInputRate::eVertex;
+        return desc;
+    }
+
+    static std::array<vk::VertexInputAttributeDescription, 2> attributeDescriptions() {
+        std::array<vk::VertexInputAttributeDescription, 2> attrs{};
+        attrs[0].binding = 0;
+        attrs[0].location = 0;
+        attrs[0].format = vk::Format::eR32G32B32Sfloat;
+        attrs[0].offset = offsetof(Vertex, pos);
+
+        attrs[1].binding = 0;
+        attrs[1].location = 1;
+        attrs[1].format = vk::Format::eR32G32B32Sfloat;
+        attrs[1].offset = offsetof(Vertex, color);
+        return attrs;
+    }
+};

--- a/src/vulkan/Pipeline.cpp
+++ b/src/vulkan/Pipeline.cpp
@@ -20,7 +20,10 @@ std::vector<char> Pipeline::readFile(const std::string &filename) const {
 
 Pipeline::Pipeline(vk::Device device, vk::Format colorAttachmentFormat,
                    const std::string &vertShaderPath, const std::string &fragShaderPath,
-                   const std::vector<vk::DescriptorSetLayout> &setLayouts, uint32_t samples)
+                   const std::vector<vk::DescriptorSetLayout> &setLayouts, uint32_t samples,
+                   vk::Format depthFormat,
+                   const std::vector<vk::VertexInputBindingDescription> &bindings,
+                   const std::vector<vk::VertexInputAttributeDescription> &attributes)
     : m_device(device) {
     // 1. Read shader code from files
     auto vertShaderCode = readFile(vertShaderPath);
@@ -41,8 +44,12 @@ Pipeline::Pipeline(vk::Device device, vk::Format colorAttachmentFormat,
 
     vk::PipelineShaderStageCreateInfo shaderStages[] = {vertStageInfo, fragStageInfo};
 
-    // 3. Vertex input (empty, for a basic triangle with no vertex buffer)
+    // 3. Vertex input
     vk::PipelineVertexInputStateCreateInfo vertexInputInfo{};
+    vertexInputInfo.vertexBindingDescriptionCount   = static_cast<uint32_t>(bindings.size());
+    vertexInputInfo.pVertexBindingDescriptions      = bindings.data();
+    vertexInputInfo.vertexAttributeDescriptionCount = static_cast<uint32_t>(attributes.size());
+    vertexInputInfo.pVertexAttributeDescriptions    = attributes.data();
 
     // 4. Input assembly
     vk::PipelineInputAssemblyStateCreateInfo inputAssembly{};
@@ -100,7 +107,7 @@ Pipeline::Pipeline(vk::Device device, vk::Format colorAttachmentFormat,
     renderingInfo.colorAttachmentCount    = 1;
     renderingInfo.pColorAttachmentFormats = &colorAttachmentFormat;
     renderingInfo.viewMask                = 0;
-    renderingInfo.depthAttachmentFormat   = vk::Format::eUndefined;
+    renderingInfo.depthAttachmentFormat   = depthFormat;
     renderingInfo.stencilAttachmentFormat = vk::Format::eUndefined;
 
     // 11. Create graphics pipeline

--- a/src/vulkan/Pipeline.hpp
+++ b/src/vulkan/Pipeline.hpp
@@ -10,7 +10,10 @@ namespace reactor {
     public:
         Pipeline(vk::Device device, vk::Format colorAttachmentFormat,
                  const std::string& vertShaderPath, const std::string& fragShaderPath,
-                 const std::vector<vk::DescriptorSetLayout>& setLayouts, uint32_t samples);
+                 const std::vector<vk::DescriptorSetLayout>& setLayouts, uint32_t samples,
+                 vk::Format depthFormat = vk::Format::eUndefined,
+                 const std::vector<vk::VertexInputBindingDescription>& bindings = {},
+                 const std::vector<vk::VertexInputAttributeDescription>& attributes = {});
         ~Pipeline();
 
         vk::Pipeline get() const { return m_pipeline; }

--- a/src/vulkan/VulkanRenderer.hpp
+++ b/src/vulkan/VulkanRenderer.hpp
@@ -59,7 +59,11 @@ private:
 
     std::vector<std::unique_ptr<Image>> m_resolveImages;
     std::vector<vk::ImageView> m_resolveViews;
+    std::vector<std::unique_ptr<Image>> m_depthImages;
+    std::vector<vk::ImageView> m_depthViews;
     std::vector<vk::DescriptorSet> m_sceneViewImageDescriptorSets;
+
+    std::unique_ptr<Buffer> m_vertexBuffer;
 
     void createCoreVulkanObjects();
     void createSwapchainAndFrameManager();
@@ -67,12 +71,16 @@ private:
     void setupUI();
     void createMSAAImage();
     void createResolveImages();
+    void createDepthImages();
     void createSampler();
     void createDescriptorSets();
+    void createVertexBuffer();
 
     void handleSwapchainResizing();
     void beginCommandBuffer(vk::CommandBuffer cmd);
-    void beginDynamicRendering(vk::CommandBuffer cmd, vk::ImageView imageView, vk::Extent2D extent, bool clear);
+    void beginDynamicRendering(vk::CommandBuffer cmd, vk::ImageView imageView,
+                               vk::Extent2D extent, bool clear,
+                               vk::ImageView depthView = {});
     void bindDescriptorSets(vk::CommandBuffer cmd);
     void drawGeometry(vk::CommandBuffer cmd);
     void renderUI(vk::CommandBuffer cmd) const;


### PR DESCRIPTION
## Summary
- update vertex shader to use vertex attributes
- create depth attachments per frame
- add vertex buffer with cube geometry
- configure pipeline for vertex input and depth testing

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_686f132a19d88330bef391c5fefd8d90