### PR TITLE
Resolve MSAA inline with dynamic rendering

### DIFF
--- a/src/vulkan/VulkanRenderer.hpp
+++ b/src/vulkan/VulkanRenderer.hpp
@@ -111,7 +111,13 @@ private:
 
     void handleSwapchainResizing();
     void beginCommandBuffer(vk::CommandBuffer cmd);
-    void beginDynamicRendering(vk::CommandBuffer cmd, vk::ImageView colorImageView, vk::ImageView depthImageView, vk::Extent2D extent, bool clearColor, bool clearDepth);
+    void beginDynamicRendering(vk::CommandBuffer cmd,
+                               vk::ImageView colorImageView,
+                               vk::ImageView resolveImageView,
+                               vk::ImageView depthImageView,
+                               vk::Extent2D extent,
+                               bool clearColor = true,
+                               bool clearDepth = false);
     void bindDescriptorSets(vk::CommandBuffer cmd);
     void drawGeometry(vk::CommandBuffer cmd);
     void renderUI(vk::CommandBuffer cmd) const;

--- a/src/vulkan/VulkanUtils.hpp
+++ b/src/vulkan/VulkanUtils.hpp
@@ -2,37 +2,16 @@
 
 #include <vulkan/vulkan.hpp>
 
-namespace reactor::utils {
+namespace reactor::utils
+{
 
-
-
-inline void resolveMSAAImageTo(vk::CommandBuffer cmd, vk::Image msaaImage, vk::Image resolveImage,
-                               uint32_t width, uint32_t height) {
-
-
-
-    vk::ImageResolve resolveRegion{};
-    resolveRegion.srcSubresource.aspectMask     = vk::ImageAspectFlagBits::eColor;
-    resolveRegion.srcSubresource.mipLevel       = 0;
-    resolveRegion.srcSubresource.baseArrayLayer = 0;
-    resolveRegion.srcSubresource.layerCount     = 1;
-    resolveRegion.srcOffset                     = vk::Offset3D{0, 0, 0};
-    resolveRegion.dstSubresource                = resolveRegion.srcSubresource;
-    resolveRegion.dstOffset                     = vk::Offset3D{0, 0, 0};
-    resolveRegion.extent                        = vk::Extent3D{width, height, 1};
-
-    cmd.resolveImage(msaaImage, // srcImage
-                     vk::ImageLayout::eTransferSrcOptimal,
-                     resolveImage, // dstImage
-                     vk::ImageLayout::eTransferDstOptimal, 1, &resolveRegion);
-}
-
-inline void setupViewportAndScissor(vk::CommandBuffer cmd, vk::Extent2D extent) {
+inline void setupViewportAndScissor(vk::CommandBuffer cmd, vk::Extent2D extent)
+{
     vk::Viewport viewport{};
-    viewport.x        = 0.0f;
-    viewport.y        = 0.0f;
-    viewport.width    = static_cast<float>(extent.width);
-    viewport.height   = static_cast<float>(extent.height);
+    viewport.x = 0.0f;
+    viewport.y = 0.0f;
+    viewport.width = static_cast<float>(extent.width);
+    viewport.height = static_cast<float>(extent.height);
     viewport.minDepth = 0.0f;
     viewport.maxDepth = 1.0f;
     cmd.setViewport(0, viewport);
@@ -41,8 +20,10 @@ inline void setupViewportAndScissor(vk::CommandBuffer cmd, vk::Extent2D extent) 
     cmd.setScissor(0, scissor);
 }
 
-inline vk::SampleCountFlagBits mapSampleCountFlag(uint32_t sampleCount) {
-    switch (sampleCount) {
+inline vk::SampleCountFlagBits mapSampleCountFlag(uint32_t sampleCount)
+{
+    switch (sampleCount)
+    {
     case 1:
         return vk::SampleCountFlagBits::e1;
     case 2:


### PR DESCRIPTION
## Summary
- Resolve MSAA color buffer directly during geometry rendering via dynamic rendering resolve attachments
- Remove transfer-based MSAA resolve path and helper
- Simplify MSAA and resolve image creation flags

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Vulkan (missing: Vulkan_LIBRARY Vulkan_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_68969436a4048330b4656f336f4011fd