### PR TITLE
Use timeline semaphores for frame management

### DIFF
--- a/src/vulkan/FrameManager.cpp
+++ b/src/vulkan/FrameManager.cpp
@@ -1,5 +1,6 @@
 #include "FrameManager.hpp"
 
+#include <array>
 #include <stdexcept>
 #include <vector>
 
@@ -25,8 +26,6 @@ FrameManager::FrameManager(vk::Device device, Allocator& allocator, uint32_t com
             1
         };
         frame.commandBuffer = m_device.allocateCommandBuffers(allocInfo)[0];
-        vk::FenceCreateInfo fenceInfo{vk::FenceCreateFlagBits::eSignaled};
-        frame.inFlightFence = m_device.createFence(fenceInfo);
 
         // create a uniform buffer
         frame.uniformBuffer = std::make_unique<Buffer>(allocator, 1024, vk::BufferUsageFlagBits::eUniformBuffer, VMA_MEMORY_USAGE_CPU_ONLY);
@@ -44,7 +43,16 @@ FrameManager::FrameManager(vk::Device device, Allocator& allocator, uint32_t com
         m_renderFinishedSemaphores[i] = m_device.createSemaphore(semaphoreInfo);
     }
 
-    m_imagesInFlight.resize(swapchainImageCount, VK_NULL_HANDLE);
+    vk::SemaphoreTypeCreateInfo timelineCreateInfo{};
+    timelineCreateInfo.semaphoreType = vk::SemaphoreType::eTimeline;
+    timelineCreateInfo.initialValue = 0;
+
+    vk::SemaphoreCreateInfo timelineSemaphoreInfo{};
+    timelineSemaphoreInfo.pNext = &timelineCreateInfo;
+
+    m_renderTimelineSemaphore = m_device.createSemaphore(timelineSemaphoreInfo);
+
+    m_imagesInFlight.resize(swapchainImageCount, 0);
 
 }
 
@@ -59,10 +67,8 @@ FrameManager::~FrameManager() {
         m_device.destroySemaphore(semaphore);
     }
 
-    for (auto& frame : m_frames) {
-        if (frame.inFlightFence) {
-            m_device.destroyFence(frame.inFlightFence);
-        }
+    if (m_renderTimelineSemaphore) {
+        m_device.destroySemaphore(m_renderTimelineSemaphore);
     }
 
     if (m_commandPool) {
@@ -71,9 +77,21 @@ FrameManager::~FrameManager() {
 }
 
 bool FrameManager::beginFrame(vk::SwapchainKHR swapchain, uint32_t& outImageIndex) {
-   vk::Result result = m_device.waitForFences(m_frames[m_currentFrame].inFlightFence, VK_TRUE, UINT64_MAX);
-    if (result != vk::Result::eSuccess) {
-        throw std::runtime_error("Failed to wait for fence!");
+    Frame& frame = m_frames[m_currentFrame];
+
+    if (frame.timelineValue > 0) {
+        uint64_t waitValue = frame.timelineValue;
+        vk::SemaphoreWaitInfo waitInfo{};
+        waitInfo.semaphoreCount = 1;
+        waitInfo.pSemaphores = &m_renderTimelineSemaphore;
+        waitInfo.pValues = &waitValue;
+
+        vk::Result result = m_device.waitSemaphores(waitInfo, UINT64_MAX);
+        if (result != vk::Result::eSuccess) {
+            throw std::runtime_error("Failed to wait for timeline semaphore!");
+        }
+
+        frame.timelineValue = 0;
     }
 
     auto resultValue = m_device.acquireNextImageKHR(
@@ -92,18 +110,20 @@ bool FrameManager::beginFrame(vk::SwapchainKHR swapchain, uint32_t& outImageInde
 
    outImageIndex = resultValue.value;
 
-    if (m_imagesInFlight[outImageIndex] != VK_NULL_HANDLE) {
-        auto ret = m_device.waitForFences(m_imagesInFlight[outImageIndex], VK_TRUE, UINT64_MAX);
-        if (ret != vk::Result::eSuccess)
-        {
-            throw std::runtime_error("Failed to wait for fence!");
+    if (m_imagesInFlight[outImageIndex] > 0) {
+        uint64_t waitValue = m_imagesInFlight[outImageIndex];
+        vk::SemaphoreWaitInfo waitInfo{};
+        waitInfo.semaphoreCount = 1;
+        waitInfo.pSemaphores = &m_renderTimelineSemaphore;
+        waitInfo.pValues = &waitValue;
+
+        vk::Result result = m_device.waitSemaphores(waitInfo, UINT64_MAX);
+        if (result != vk::Result::eSuccess) {
+            throw std::runtime_error("Failed to wait for timeline semaphore!");
         }
+
+        m_imagesInFlight[outImageIndex] = 0;
     }
-
-    // Associate the current frame's fence with the acquired swapchain image
-    m_imagesInFlight[outImageIndex] = m_frames[m_currentFrame].inFlightFence;
-
-    m_device.resetFences(m_frames[m_currentFrame].inFlightFence);
 
     return true;
 }
@@ -113,14 +133,30 @@ void FrameManager::endFrame(vk::Queue graphicsQueue, vk::Queue presentQueue, vk:
 
     vk::PipelineStageFlags waitStages = vk::PipelineStageFlagBits::eColorAttachmentOutput;
 
+    std::array<vk::Semaphore, 2> signalSemaphores{m_renderFinishedSemaphores[imageIndex], m_renderTimelineSemaphore};
+
     vk::SubmitInfo submitInfo{
         1, &m_imageAvailableSemaphores[m_currentFrame],
         &waitStages,
         1, &frame.commandBuffer,
-        1, &m_renderFinishedSemaphores[imageIndex]
+        static_cast<uint32_t>(signalSemaphores.size()), signalSemaphores.data()
     };
 
-    graphicsQueue.submit(submitInfo, frame.inFlightFence);
+    uint64_t waitValues[] = {0};
+    std::array<uint64_t, 2> signalValues{0, ++m_nextTimelineValue};
+
+    vk::TimelineSemaphoreSubmitInfo timelineInfo{};
+    timelineInfo.waitSemaphoreValueCount = 1;
+    timelineInfo.pWaitSemaphoreValues = waitValues;
+    timelineInfo.signalSemaphoreValueCount = static_cast<uint32_t>(signalValues.size());
+    timelineInfo.pSignalSemaphoreValues = signalValues.data();
+
+    submitInfo.pNext = &timelineInfo;
+
+    graphicsQueue.submit(submitInfo, vk::Fence());
+
+    frame.timelineValue = signalValues.back();
+    m_imagesInFlight[imageIndex] = frame.timelineValue;
 
     vk::PresentInfoKHR presentInfo{
         1, &m_renderFinishedSemaphores[imageIndex],

--- a/src/vulkan/FrameManager.hpp
+++ b/src/vulkan/FrameManager.hpp
@@ -5,6 +5,9 @@
 #ifndef FRAMEMANAGER_HPP
 #define FRAMEMANAGER_HPP
 
+#include <cstdint>
+#include <memory>
+#include <vector>
 #include <vulkan/vulkan.hpp>
 
 #include "buffer.h"
@@ -13,7 +16,7 @@ namespace reactor {
     // Using the Frame struct from our previous discussion
     struct Frame {
         vk::CommandBuffer commandBuffer;
-        vk::Fence inFlightFence;
+        uint64_t timelineValue = 0;
         vk::DescriptorSet cameraDescriptorSet;
         std::unique_ptr<Buffer> uniformBuffer;
     };
@@ -44,7 +47,9 @@ namespace reactor {
         std::vector<Frame> m_frames;
         std::vector<vk::Semaphore> m_imageAvailableSemaphores;
         std::vector<vk::Semaphore> m_renderFinishedSemaphores;
-        std::vector<vk::Fence> m_imagesInFlight;
+        vk::Semaphore m_renderTimelineSemaphore;
+        std::vector<uint64_t> m_imagesInFlight;
+        uint64_t m_nextTimelineValue = 0;
         size_t m_currentFrame;
         size_t m_framesInFlightCount;
     };

--- a/src/vulkan/VulkanContext.cpp
+++ b/src/vulkan/VulkanContext.cpp
@@ -179,7 +179,11 @@ void VulkanContext::createLogicalDevice() {
     vk::PhysicalDeviceVulkan11Features vulkan11Features{};
     vulkan11Features.shaderDrawParameters = VK_TRUE;
 
-    dynamicRenderingFeatures.pNext = &vulkan11Features;
+    vk::PhysicalDeviceTimelineSemaphoreFeatures timelineSemaphoreFeatures{};
+    timelineSemaphoreFeatures.timelineSemaphore = VK_TRUE;
+
+    dynamicRenderingFeatures.pNext = &timelineSemaphoreFeatures;
+    timelineSemaphoreFeatures.pNext = &vulkan11Features;
 
     std::vector<const char*> deviceExtensions = {
         VK_KHR_SWAPCHAIN_EXTENSION_NAME,


### PR DESCRIPTION
## Summary
- replace per-frame fences with a timeline semaphore to manage CPU/GPU synchronization
- ensure swapchain image reuse waits on the appropriate timeline semaphore values
- enable the timeline semaphore feature when creating the logical device

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f84313d168833099965ffc72e81c34